### PR TITLE
Enabling /render/dashboard-solo/db GET method to render panels to .png

### DIFF
--- a/Grafana Home Dashboard.indigoPlugin/Contents/Server Plugin/servers/grafana/conf/defaults.ini
+++ b/Grafana Home Dashboard.indigoPlugin/Contents/Server Plugin/servers/grafana/conf/defaults.ini
@@ -240,7 +240,8 @@ disable_signout_menu = false
 #################################### Anonymous Auth ######################
 [auth.anonymous]
 # enable anonymous access
-enabled = false
+# enabled in order to allow anonymous calls to render GET method
+enabled = true
 
 # specify organization name that should be used for unauthenticated users
 org_name = Main Org.


### PR DESCRIPTION
Enables you to (in theory) render the current state of a Grafana dashboard panel to a .png image file.  Note that in order to support Indigo control pages pulling up a refreshing image URL, anonymous access to Grafana is needed.  This is because Grafana does not support passing authentication credentials as part of the URL (only as parameters using e.g. curl command line switches).  Note that this reduces the security of the overall indigo-grafana-dashboard somewhat, as the grafana web server running on the Indigo server is now open to anyone who has un-firewalled network access to that machine.  Ideally turning on anonymous access to support control pages should be a controllable configuration option of the indigo-grafana-dashboard plugin.

Example usage: if you had a Grafana dashboard called 'indigo', you could use the following URL to render the current state of the first panel on that dashboard to a .png: http://localhost:3006/render/dashboard-solo/db/indigo?orgId=1&panelId=1&width=1000&height=500&timeout=5000

The phantoms binary included is version 2.1.1, downloaded from: http://phantomjs.org/download.html